### PR TITLE
Add AtmosProfile types

### DIFF
--- a/src/AtmosProfileTypes.jl
+++ b/src/AtmosProfileTypes.jl
@@ -1,0 +1,40 @@
+#= This is an experimental design, but perhaps it's not needed.=#
+module AtmosProfileTypes
+
+abstract type AbstractProfileType end
+abstract type AbstractProfile1D <: AbstractProfileType end
+abstract type AbstractProfile2D <: AbstractProfileType end
+struct zProfile <: AbstractProfile1D end
+struct tProfile <: AbstractProfile1D end
+struct tzProfile <: AbstractProfile2D end
+
+"""
+    AtmosphericProfile{T}(profile::P)
+
+An atmospheric profile, which is callable
+object or function with arguments:
+
+    - `profile(z)` (altitude [m])
+    - `profile(t)` (time [s])
+    - `profile(t, z)` (time [s], altitude [m])
+
+For example, if we just use a function, we have
+```julia
+profile = z-> 2*z
+```
+We can call this function with `profile(10.0)`.
+"""
+struct AtmosphericProfile{T, P}
+    profile::P
+    AtmosphericProfile{T}(profile::P) where {T, P} = new{T, P}(profile)
+end
+
+function (p::AtmosphericProfile{<:AbstractProfile2D})(t, z)
+    p.profile(t, z)
+end
+
+function (p::AtmosphericProfile{<:AbstractProfile1D})(z_or_t)
+    p.profile(z_or_t)
+end
+
+end # module


### PR DESCRIPTION
This is only an idea. It might be nice if we always return a (here added) `AtmosphericProfile`, which has a callable profile.

We could potentially add tests for it, more systematically, and maybe add pretty printing for how the object is called. But Idk how important this really is, so I'll just leave it as a draft PR for now.