### PR TITLE
Add Dycoms  RF01 and RF02 profiles

### DIFF
--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -2,6 +2,17 @@
 #    Last author name (titlecase), followed by
 #    (no characters in-between) the year.
 
+@article{Ackerman2009,
+  title = {Large-Eddy Simulations of a Drizzling, Stratocumulus-Topped Marine Boundary Layer},
+  author = {Andrew S. Ackerman and Margreet C. vanZanten and Bjorn Stevens and Verica Savic-Jovcic and Christopher S. Bretherton and Andreas Chlond and Jean-Christophe Golaz and Hongli Jiang and Marat Khairoutdinov and Steven K. Krueger and David C. Lewellen and Adrian Lock and Chin-Hoh Moeng and Kozo Nakamura and Markus D. Petters and Jefferson R. Snider and Sonja Weinbrecht and Mike Zulauf},
+  journal = {Monthly Weather Review},
+  volume = {137},
+  number = {3},
+  year = {2009},
+  pages = {1083--1110},
+  doi = {10.1175/2008MWR2582.1}
+}
+
 @article{Brown2002,
   title = {Large-eddy simulation of the diurnal cycle of shallow cumulus convection over land},
   author = {Brown, AR and Cederwall, RT and Chlond, A and Duynkerke, PG and Golaz, J-C and Khairoutdinov, M and Lewellen, DC and Lock, AP and MacVean, MK and Moeng, C-H and others},
@@ -64,6 +75,17 @@
   year = {2004},
   publisher = {Wiley Online Library},
   doi = {https://doi.org/10.1256/qj.03.223}
+}
+
+@article{Stevens2005,
+  title = {Evaluation of large-eddy simulations via observations of nocturnal marine stratocumulus},
+  author = {Stevens, Bjorn and Moeng, Chin-Hoh and Ackerman, Andrew S and Bretherton, Christopher S and Chlond, Andreas and de Roode, Stephan and Edwards, James and Golaz, Jean-Christophe and Jiang, Hongli and Khairoutdinov, Marat and others},
+  journal = {Monthly weather review},
+  volume = {133},
+  number = {6},
+  pages = {1443--1462},
+  year = {2005},
+  doi = {http://dx.doi.org/10.1175/MWR2930.1}
 }
 
 @article{Tan2018,

--- a/docs/src/plot_profiles.jl
+++ b/docs/src/plot_profiles.jl
@@ -8,6 +8,8 @@ function units(var::String)
     var == "q_tot" && return "[kg/kg]"
     var == "u" && return "[m/s]"
     var == "v" && return "[m/s]"
+    var == "u0" && return "[m/s]"
+    var == "v0" && return "[m/s]"
     var == "tke" && return "[m^2/s^2]"
     var == "dTdt" && return "[K/s]"
     var == "dqtdt" && return "[kg/(kg s)]"
@@ -95,6 +97,21 @@ z_profiles = [
     (; func = APL.GABLS_geostrophic_vg , kwargs = (;z_range, xlabel = "v")),
 
     (; func = APL.DryBubble_θ          , kwargs = (;z_range, xlabel = "θ_liq_ice")),
+
+    (; func = APL.Dycoms_RF01_θ_liq_ice  , kwargs = (;z_range, xlabel = "θ_liq_ice")),
+    (; func = APL.Dycoms_RF01_q_tot      , kwargs = (;z_range, xlabel = "q_tot")),
+    (; func = APL.Dycoms_RF01_u0         , kwargs = (;z_range, xlabel = "u0")),
+    (; func = APL.Dycoms_RF01_v0         , kwargs = (;z_range, xlabel = "v0")),
+    (; func = APL.Dycoms_RF01_tke        , kwargs = (;z_range, xlabel = "tke")),
+
+    (; func = APL.Dycoms_RF02_θ_liq_ice  , kwargs = (;z_range, xlabel = "θ_liq_ice")),
+    (; func = APL.Dycoms_RF02_q_tot      , kwargs = (;z_range, xlabel = "q_tot")),
+    (; func = APL.Dycoms_RF02_u0         , kwargs = (;z_range, xlabel = "u0")),
+    (; func = APL.Dycoms_RF02_v0         , kwargs = (;z_range, xlabel = "v0")),
+    (; func = APL.Dycoms_RF02_u          , kwargs = (;z_range, xlabel = "u")),
+    (; func = APL.Dycoms_RF02_v          , kwargs = (;z_range, xlabel = "v")),
+    (; func = APL.Dycoms_RF02_tke        , kwargs = (;z_range, xlabel = "tke")),
+
 ]
 
 #####

--- a/src/AtmosphericProfilesLibrary.jl
+++ b/src/AtmosphericProfilesLibrary.jl
@@ -13,5 +13,7 @@ include("profiles/ARM_SGP.jl")
 include("profiles/GATE_III.jl")
 include("profiles/GABLS.jl")
 include("profiles/DryBubble.jl")
+include("profiles/Dycoms_RF01.jl")
+include("profiles/Dycoms_RF02.jl")
 
 end # module

--- a/src/profiles/Dycoms_RF01.jl
+++ b/src/profiles/Dycoms_RF01.jl
@@ -1,0 +1,26 @@
+""" [Stevens2005](@cite) """
+Dycoms_RF01_q_tot(::Type{FT}) where {FT} = z -> if z <= 840.0
+        FT(9.0) / FT(1000.0)
+    else
+        FT(1.5) / FT(1000.0)
+    end
+
+""" [Stevens2005](@cite) """
+Dycoms_RF01_θ_liq_ice(::Type{FT}) where {FT} = z -> if z <= 840.0
+        FT(289)
+    else
+        FT(297.5) + (z - FT(840))^FT(1.0 / 3.0)
+    end
+
+""" [Stevens2005](@cite) """
+Dycoms_RF01_u0(::Type{FT}) where {FT} = z -> FT(7)
+
+""" [Stevens2005](@cite) """
+Dycoms_RF01_v0(::Type{FT}) where {FT} = z -> FT(-5.5)
+
+""" [Stevens2005](@cite) """
+Dycoms_RF01_tke(::Type{FT}) where {FT} = z -> if z <= 800.0
+        FT(1) - z / FT(1000)
+    else
+        FT(0)
+    end

--- a/src/profiles/Dycoms_RF02.jl
+++ b/src/profiles/Dycoms_RF02.jl
@@ -1,0 +1,38 @@
+""" [Ackerman2009](@cite) """
+Dycoms_RF02_q_tot(::Type{FT}) where {FT} = z -> if z <= 840.0
+        FT(9.45) / FT(1000.0)
+    else
+        (FT(5) - FT(3) * (FT(1) - exp(-(z - FT(795)) / FT(500)))) / FT(1000)
+    end
+
+""" [Ackerman2009](@cite) """
+Dycoms_RF02_θ_liq_ice(::Type{FT}) where {FT} = z -> if z <= 795.0
+        FT(288.3)
+    else
+        FT(295.0) + (z - FT(795))^FT(1.0 / 3.0)
+    end
+
+""" [Ackerman2009](@cite) """
+Dycoms_RF02_u0(::Type{FT}) where {FT} = z -> FT(5)
+
+""" [Ackerman2009](@cite) """
+Dycoms_RF02_v0(::Type{FT}) where {FT} = z -> FT(-5.5)
+
+""" [Ackerman2009](@cite) """
+function Dycoms_RF02_u(::Type{FT}) where {FT}
+    u0 = Dycoms_RF02_u0(FT)
+    return z -> FT(3) + FT(4.3) * z / FT(1000) - u0(z)
+end
+
+""" [Ackerman2009](@cite) """
+function Dycoms_RF02_v(::Type{FT}) where {FT}
+    v0 = Dycoms_RF02_v0(FT)
+    return z -> FT(-9) + FT(5.6) * z / FT(1000) - v0(z)
+end
+
+""" [Ackerman2009](@cite) """
+Dycoms_RF02_tke(::Type{FT}) where {FT} = z -> if z <= 795.0
+        FT(1) - z / FT(1000)
+    else
+        FT(0)
+    end


### PR DESCRIPTION
Not sure about how to handle this:

https://github.com/CliMA/TurbulenceConvection.jl/blob/cf982f66d36664f47fdf9f841c92d4ce2e453b16/driver/Cases.jl#L1195-L1196

and 

https://github.com/CliMA/TurbulenceConvection.jl/blob/cf982f66d36664f47fdf9f841c92d4ce2e453b16/driver/Cases.jl#L1301-L1302

as they should be the same as the u0 and v0 from the horizontal velocity profiles. In Dycoms_RF01 the final horizontal profiles are equal to u0 and v0. In Dycoms_RF02 they are not.

Should I define another function here that returns them as constants?