### PR TITLE
Add VSCode artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ docs/src/generated_profile_library.md
 # committed for packages, but should be committed for applications that require a static
 # environment.
 Manifest.toml
+
+# ignore vscode artifacts
+*.vscode
+*.DS


### PR DESCRIPTION
Identical approach to e.g. ClimaAtmos.jl:

https://github.com/CliMA/ClimaAtmos.jl/blob/898cf2e017395d5c4c2a879c4d2fa633f97a9ebe/.gitignore#L37-L39