### PR TITLE
Add .DS_store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ Manifest.toml
 # ignore vscode artifacts
 *.vscode
 *.DS
+.DS_store


### PR DESCRIPTION
This PR simply adds `.DS_store` to .gitignore, which can show as an untracked file on MacOS. `.DS_store` is a file containing folder metadata and is not related to AtmosphericProfilesLibrary.jl.

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [X] I have read and checked the items on the review checklist.
