### PR TITLE
Remove unnecessary dependency

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,2 @@
 [deps]
-AtmosphericProfilesLibrary = "86bc3604-9858-485a-bdbe-831ec50de11d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Removes AtmopshericProfilesLibrary from list of deps in test/Project.toml.
