### PR TITLE
Patch release with bumped Interpolations.jl compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,6 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 ClimaInterpolations = "0.1.1"
-Interpolations = "0.14, 0.15"
+Interpolations = "0.14, 0.15, 0.16"
 StaticArrays = "1"
 julia = "1.9"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
 I believe this is needed to support the latest Interpolations.jl in ClimaAtmos. See [this](https://github.com/CliMA/ClimaAtmos.jl/pull/4694) PR.


The same was done in #46 for the last minor Interpolations.jl release

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
